### PR TITLE
Rest of the APIs

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -210,4 +210,482 @@ router.post("/reset-password/:token", async (req, res) => {
   }
 });
 
+// Gets youself to follow User B.
+// To this this to work on postman: Add header Authorization | Bearer <jwtToken>
+router.post("/follow/:id", auth, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const followingId = req.params.id;
+
+    // Finds your id and user B
+    const user = await User.findById(userId);
+    const following = await User.findById(followingId);
+
+    // posible errors
+    if (!following) return res.status(404).json({ error: "User not found" });
+    if (user._id.toString() === following._id.toString()) {
+      return res.status(400).json({ error: "You cannot follow yourself" });
+    }
+    if (user.following.some((id) => id.toString() === followingId)) {
+      return res.status(400).json({ error: "You already follow this user" });
+    }
+
+    // updates your following list and user b's follower list
+    user.following.push(following._id);
+    following.followers.push(user._id);
+
+    await user.save();
+    await following.save();
+
+    res
+      .status(200)
+      .json({ message: `You are now following ${following.username}` });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Unfollow a user
+// To use in Postman: Add header Authorization | Bearer <jwtToken>
+router.post("/unfollow/:id", auth, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const unfollowId = req.params.id;
+
+    // Find both users
+    const user = await User.findById(userId);
+    const unfollowUser = await User.findById(unfollowId);
+
+    // types of error
+    if (!unfollowUser) {
+      return res.status(404).json({ error: "User not found" });
+    }
+    if (user._id.toString() === unfollowUser._id.toString()) {
+      return res.status(400).json({ error: "You cannot unfollow yourself" });
+    }
+
+    if (!user.following.some((id) => id.toString() === unfollowId)) {
+      return res.status(400).json({ error: "You are not following this user" });
+    }
+
+    // Remove each from the other's array
+    user.following = user.following.filter(
+      (id) => id.toString() !== unfollowId
+    );
+    unfollowUser.followers = unfollowUser.followers.filter(
+      (id) => id.toString() !== userId
+    );
+
+    // Save changes
+    await user.save();
+    await unfollowUser.save();
+
+    res
+      .status(200)
+      .json({ message: `You have unfollowed ${unfollowUser.username}` });
+  } catch (error) {
+    console.error("Error in /unfollow/:id:", error.message);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Get current user's profile secured
+// get jwt token from login enpoint
+// On postman: Add header Authorization | Bearer <jwtToken>
+router.get("/profile/me", auth, async (req, res) => {
+  try {
+    //Gets the user and displays info, no password, and follower/following username
+    const user = await User.findById(req.user.id)
+      .select("-password")
+      .populate("followers", "username")
+      .populate("following", "username")
+      .lean(); // plain JS object
+
+    // Replace followers/following with just usernames
+    user.followers = user.followers.map((f) => f.username);
+    user.following = user.following.map((f) => f.username);
+
+    // # of followers/following (unsure if needed)
+    // user.followersCount = user.followers.length;
+    // user.followingCount = user.following.length;
+
+    res.json(user);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// edit your profile's username and bio
+// get jwt token from login enpoint
+// On postman: Add header Authorization | Bearer <jwtToken>
+router.post("/profile/edit", auth, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const { username, bio } = req.body;
+
+    // Find the user
+    const user = await User.findById(userId);
+    if (!user) return res.status(404).json({ error: "User not found" });
+
+    // Only update allowed fields
+    // if bio is "" it clears it, not in body does nothing
+    if (username) user.username = username;
+    if (bio !== undefined) user.bio = bio;
+
+    // Save changes
+    await user.save();
+
+    // Return updated user (without password/)
+    const updatedUser = await User.findById(userId)
+      .select("-password -email")
+      .populate("followers", "username")
+      .populate("following", "username");
+
+    res.status(200).json(updatedUser);
+  } catch (error) {
+    // Handle duplicate username
+    if (error.code === 11000) {
+      return res.status(400).json({ error: "Username already in use" });
+    }
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// delete your own profile ( haven't tested yet, no errors do)
+// get jwt token from login enpoint
+// On postman: Add header Authorization | Bearer <jwtToken>
+router.post("/profile/delete", auth, async (req, res) => {
+  try {
+    const userId = req.user.id;
+
+    // Find user
+    const user = await User.findById(userId);
+    if (!user) return res.status(404).json({ error: "User not found" });
+
+    // Remove this user from other users' followers/following arrays
+    await User.updateMany(
+      { followers: userId },
+      { $pull: { followers: userId } }
+    );
+    await User.updateMany(
+      { following: userId },
+      { $pull: { following: userId } }
+    );
+
+    // Delete the user
+    await User.findByIdAndDelete(userId);
+
+    res.status(200).json({ message: "Your account has been deleted" });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// GET all reviews by a specific user (public)
+router.get("/profile/:id/reviews", async (req, res) => {
+  try {
+    const userId = req.params.id;
+
+    // Validate ObjectId
+    if (!mongoose.Types.ObjectId.isValid(userId)) {
+      return res.status(400).json({ error: "Invalid user ID" });
+    }
+
+    // Check if user exists
+    const user = await User.findById(userId).select("username").lean();
+    if (!user) return res.status(404).json({ error: "User not found" });
+
+    // Get reviews, newest first
+    const reviews = await Review.find({ user: userId })
+      .sort({ createdAt: -1 })
+      .populate("game", "title") // populate only title
+      .lean();
+
+    // Format reviews
+    const formatted = reviews.map((r) => ({
+      id: r._id,
+      game: r.game?.title || "Unknown",
+      rating: r.rating,
+      body: r.body,
+      createdAt: r.createdAt,
+    }));
+
+    res.json({
+      user: user.username,
+      reviews: formatted, // empty array if no reviews
+    });
+  } catch (error) {
+    console.error("Error fetching user reviews:", error.message);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+// Get any user's profile by ID same as above without auth (secure)
+router.get("/profile/:id", async (req, res) => {
+  try {
+    //Gets the user and displays info, no password, and follower/following username
+    const user = await User.findById(req.params.id)
+      .select("-password")
+      .populate("followers", "username")
+      .populate("following", "username")
+      .lean(); // plain JS object
+
+    // error if incorrect id
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    // Replace followers/following with just usernames
+    user.followers = user.followers.map((f) => f.username);
+    user.following = user.following.map((f) => f.username);
+
+    // # of followers/following (unsure if needed)
+    // user.followersCount = user.followers.length;
+    // user.followingCount = user.following.length;
+
+    res.json(user);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// GET /game with multiple search parameters
+// Example: /game?title=Zelda&genre=Adventure&platform=Switch&publisher=Nintendo
+// will eventually want to add a sort option after return
+// put a limit so it doesn't brick me
+router.get("/game", async (req, res) => {
+  try {
+    //for now 20 but later add as parameter
+    const LIMIT = 20;
+
+    // optional choices in the body
+    // will error if no search parameters :/ ( for now)
+    const {
+      title,
+      genre,
+      platform,
+      release_year,
+      main_developer,
+      publisher,
+      description,
+    } = req.query;
+
+    const filter = {};
+
+    if (title) {
+      filter.title = { $regex: title, $options: "i" };
+    }
+
+    if (genre) {
+      filter.genres = { $in: [new RegExp(genre, "i")] };
+    }
+
+    if (platform) {
+      filter.platforms = { $in: [new RegExp(platform, "i")] };
+    }
+
+    // makes sure it's a number
+    if (release_year && isNaN(Number(release_year))) {
+      return res.status(400).json({ error: "release_year must be a number" });
+    }
+    if (release_year) {
+      filter.release_year = Number(release_year);
+    }
+
+    if (main_developer) {
+      filter.main_developer = { $regex: main_developer, $options: "i" };
+    }
+
+    if (publisher) {
+      filter.publisher = { $regex: publisher, $options: "i" };
+    }
+
+    if (description) {
+      filter.description = { $regex: description, $options: "i" };
+    }
+
+    // Find games matching filter, sorted alphabetically
+    const games = await Game.find(filter)
+      .sort({ title: 1 })
+      .limit(LIMIT)
+      .lean();
+
+    res.json(games);
+  } catch (error) {
+    console.error("Error fetching games:", error.message);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+// Adds game to your playlist
+// get jwt token from login enpoint
+// On postman: Add header Authorization | Bearer <jwtToken>
+router.post("/watch/:id", auth, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const gameId = req.params.id;
+
+    // Validate ObjectId
+    if (!mongoose.Types.ObjectId.isValid(gameId)) {
+      return res.status(400).json({ error: "Invalid game ID" });
+    }
+
+    // Check if game exists
+    const game = await Game.findById(gameId);
+    if (!game) {
+      return res.status(404).json({ error: "Game not found" });
+    }
+
+    // Find user
+    const user = await User.findById(userId);
+
+    // Prevent duplicates
+    if (user.playlist.some((id) => id.toString() === gameId)) {
+      return res.status(400).json({ error: "Game already in playlist" });
+    }
+
+    // Add game to playlist
+    user.playlist.push(game._id);
+    await user.save();
+
+    res.status(200).json({ message: `${game.title} added to your playlist!` });
+  } catch (error) {
+    console.error("Error adding game to playlist:", error.message);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+// deletes the game from playlist
+// get jwt token from login enpoint
+// On postman: Add header Authorization | Bearer <jwtToken>
+router.delete("/watch/:id", auth, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const gameId = req.params.id;
+
+    // Validate ObjectId
+    if (!mongoose.Types.ObjectId.isValid(gameId)) {
+      return res.status(400).json({ error: "Invalid game ID" });
+    }
+
+    // Check if game exists
+    const game = await Game.findById(gameId);
+    if (!game) {
+      return res.status(404).json({ error: "Game not found" });
+    }
+
+    // Find user
+    const user = await User.findById(userId);
+
+    // Check if game is in playlist
+    if (!user.playlist.some((id) => id.toString() === gameId)) {
+      return res.status(400).json({ error: "Game not in playlist" });
+    }
+
+    // Remove game from playlist
+    user.playlist = user.playlist.filter((id) => id.toString() !== gameId);
+    await user.save();
+
+    res
+      .status(200)
+      .json({ message: `${game.title} removed from your playlist.` });
+  } catch (error) {
+    console.error("Error removing game from playlist:", error.message);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+// make a review for a game
+// get jwt token from login enpoint
+// On postman: Add header Authorization | Bearer <jwtToken>
+router.post("/review/create", auth, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const { gameId, rating, body } = req.body;
+
+    // list of errors
+    if (!gameId || !rating || !body) {
+      return res
+        .status(400)
+        .json({ error: "gameId, rating, and body are required" });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(gameId)) {
+      return res.status(400).json({ error: "Invalid game ID" });
+    }
+
+    if (typeof rating !== "number" || rating < 0 || rating > 10) {
+      return res
+        .status(400)
+        .json({ error: "Rating must be a number between 0 and 10" });
+    }
+
+    if (body.length > 1000) {
+      return res
+        .status(400)
+        .json({ error: "Review body cannot exceed 1000 characters" });
+    }
+
+    // Check if game exists
+    const game = await Game.findById(gameId);
+    if (!game) {
+      return res.status(404).json({ error: "Game not found" });
+    }
+
+    // Can't review spam
+    const existingReview = await Review.findOne({ user: userId, game: gameId });
+    if (existingReview) {
+      return res
+        .status(400)
+        .json({ error: "You have already reviewed this game" });
+    }
+
+    // Create the review
+    const review = new Review({
+      user: userId,
+      game: gameId,
+      rating,
+      body,
+    });
+
+    await review.save();
+
+    res.status(201).json({ message: "Review created successfully", review });
+  } catch (error) {
+    console.error("Error creating review:", error.message);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+// deletes your review made for a game
+// get jwt token from login enpoint
+// On postman: Add header Authorization | Bearer <jwtToken>
+router.delete("/review/:id", auth, async (req, res) => {
+  try {
+    const reviewId = req.params.id;
+    const userId = req.user.id;
+
+    // Find the review
+    const review = await Review.findById(reviewId);
+    if (!review) {
+      return res.status(404).json({ error: "Review not found" });
+    }
+
+    // Check ownership
+    if (review.user.toString() !== userId) {
+      return res
+        .status(403)
+        .json({ error: "You are not allowed to delete this review" });
+    }
+
+    // Delete review
+    await Review.findByIdAndDelete(reviewId);
+
+    res.json({ message: "Review deleted successfully" });
+  } catch (error) {
+    console.error("Error deleting review:", error.message);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION


Has "apiTest" branch changes to this.
Added the rest of the APIs from the whiteboard
all tested with postman except for profile/delete...
POST /follow/:id – Follow another user. (auth required).
POST /unfollow/:id – Unfollow a user. (auth required).

GET /profile/me – View your profile (auth required).
POST /profile/edit – Edit username or bio. (auth required).
POST /profile/delete – Delete your account. (auth required).
GET /profile/:id – View any user’s public profile. (public)
GET /profile/:id/reviews – View a user’s reviews. (public)

GET /game – Search games with filters (title, genre, etc.). (public)
POST /watch/:id – Add a game to your playlist. (auth required).
DELETE /watch/:id – Remove a game from your playlist. (auth required).

POST /review/create – Create a new game review. (auth required).
DELETE /review/:id – Delete one of your reviews. (auth required).
I do want to go back to these and make them look cleaner and clearer.
will eventually separate them instead of having them all in auth, but just wanted to make sure these work atm.
